### PR TITLE
fixed: zip is not subscriptable

### DIFF
--- a/4.prioritized dqn.ipynb
+++ b/4.prioritized dqn.ipynb
@@ -106,7 +106,7 @@
     "        weights /= weights.max()\n",
     "        weights  = np.array(weights, dtype=np.float32)\n",
     "        \n",
-    "        batch       = zip(*samples)\n",
+    "        batch       = list(zip(*samples))\n",
     "        states      = np.concatenate(batch[0])\n",
     "        actions     = batch[1]\n",
     "        rewards     = batch[2]\n",


### PR DESCRIPTION
In python3 zip is not subscriptable. However, in the next line, there is an attempt to subscript. Thus, the zip object has been wrapped in the list so that it can be subscriptable.